### PR TITLE
Typo fix

### DIFF
--- a/Dockerfile.mmdvmdashboard
+++ b/Dockerfile.mmdvmdashboard
@@ -10,7 +10,7 @@ RUN apt-get update \
 RUN docker-php-ext-install gettext
 
 RUN git clone https://github.com/dg9vh/MMDVMHost-Dashboard.git \
-   && cp -R /MMDVMHost-Dashboard/* /var/www/html/ \ 
+   && cp -R ./MMDVMHost-Dashboard/* /var/www/html/ \ 
    && sed -i '2iini_set("display_errors",0);error_reporting(0);' /var/www/html/index.php \
    && chown -R www-data:www-data /var/www/html \
    && chmod -R 775 /var/www/html


### PR DESCRIPTION
Typo fix in `Dockerfile.mmdvmdashboard` to use local directory instead of root.

P.S. Have just started trying to bring it up. Haven't fully checked yet.